### PR TITLE
privacy policy and terms of service markdown first drafts ready

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,110 @@
+# Giglance Privacy Policy
+_Last updated: July 2, 2025_
+
+## Introduction
+
+Welcome to Giglance (“**Giglance**”, “*we*”, “*our*”, or “*us*”). This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit **https://giglance.com** (the “**Site**”) and any related services that link to this Policy (collectively, the “**Services**”).
+
+We take your privacy seriously. Please read this Policy carefully. By accessing or using our Services, you acknowledge that you have read, understood, and agree to our collection, storage, use, and disclosure of your personal information as described in this Policy.
+
+## What Information We Collect
+
+We collect information that you voluntarily provide to us when you:
+
+* create or update an account  
+* complete a profile  
+* post or accept a project  
+* communicate with other users or with us  
+* subscribe to newsletters or request support  
+
+This information may include:
+
+* Name  
+* Email address  
+* Password (hashed)  
+* Profile details such as skills, bio, or portfolio links  
+* Payment‑related identifiers (e.g., your PayPal email) — **we do not store full payment card numbers**  
+* Any other information you choose to provide  
+
+### Automatically Collected Information
+
+When you visit the Site, our servers automatically record basic technical information sent by your browser such as:
+
+* IP address  
+* Browser type and version  
+* Referring/exit pages and URLs  
+* Date/time stamps  
+* Pages viewed and the order of those pages  
+
+**We do not use browser cookies, pixel tags, or similar tracking technologies.**
+
+## How We Use Your Information
+
+We use the information we collect to:
+
+1. Provide, operate, and maintain the Services  
+2. Facilitate contracts and payments between Clients and Freelancers  
+3. Send administrative communications such as confirmations, technical notices, updates, and security alerts  
+4. Respond to comments, questions, and requests and provide customer support  
+5. Improve and expand our Services by understanding usage and performance trends  
+6. Detect, prevent, and address technical issues, fraud, or other unauthorized activities  
+7. Comply with legal obligations and enforce our Terms of Service  
+
+## Legal Bases for Processing (EEA/UK Users)
+
+If you are in the European Economic Area or the United Kingdom, our legal bases for processing your personal information are:
+
+* Performance of a contract with you  
+* Legitimate interests that are not overridden by your data‑protection interests  
+* Your consent, where we request it  
+* Compliance with a legal obligation  
+
+## How We Share Information
+
+We do **not** sell or rent your personal information.
+
+We share information only:
+
+* With service providers who perform services for us (e.g., cloud hosting, payment processors) and who are bound by contractual obligations to keep such information confidential and use it only for the purposes for which we disclose it to them  
+* To comply with legal process or lawful requests by public authorities  
+* To protect the rights, property, or safety of Giglance, our users, or others  
+* With your consent or at your direction  
+
+## Data Retention
+
+We keep your information for as long as reasonably necessary to fulfill the purposes outlined in this Policy, unless a longer retention period is required or permitted by law.
+
+## Security
+
+We employ administrative, technical, and physical safeguards designed to protect information against unauthorized access, loss, misuse, or alteration. Nevertheless, no Internet transmission or storage system is guaranteed to be 100% secure.
+
+## Your Choices and Rights
+
+Depending on your location, you may have rights such as to:
+
+* Access, correct, or delete your personal information  
+* Object to or restrict our processing of your information  
+* Withdraw consent at any time, without affecting the lawfulness of processing before the withdrawal  
+* Lodge a complaint with a supervisory authority  
+
+You can exercise most of these rights through your account settings or by contacting us at **privacy@giglance.com**.
+
+## Children’s Privacy
+
+The Services are not directed to children under 16. We do not knowingly collect personal information from children. If we learn that we have collected such information, we will delete it.
+
+## International Transfers
+
+We are based in India and may store and process information in other countries where we or our service providers operate. We take steps to ensure that such transfers comply with applicable data‑protection laws.
+
+## Changes to This Privacy Policy
+
+We may update this Privacy Policy from time to time. The “Last updated” date at the top indicates when this Policy was last revised. Your continued use of the Services after any modification signifies your acceptance of the revised Policy.
+
+## Contact Us
+
+If you have any questions about this Privacy Policy, please contact us at:
+
+**Giglance**  
+Attn: Privacy Team  
+Email: **privacy@giglance.com**

--- a/terms-of-service.md
+++ b/terms-of-service.md
@@ -1,0 +1,79 @@
+# Giglance Terms of Service
+_Last updated: July 2, 2025_
+
+PLEASE READ THESE TERMS OF SERVICE (“**Terms**”) CAREFULLY. They constitute a legally binding agreement between you (“**User**” or “*you*”) and Giglance (“**Giglance**”, “*we*”, “*our*”, or “*us*”) governing your access to and use of **https://giglance.com** and any related services that link to these Terms (collectively, the “**Services**”).
+
+By accessing or using the Services, you agree to be bound by these Terms and our Privacy Policy. If you do not agree, you must not access or use the Services.
+
+## 1. Eligibility
+
+You must be at least 16 years old and capable of forming a legally binding contract to use the Services. By using Giglance, you represent and warrant that you meet these requirements.
+
+## 2. Account Registration
+
+You may need to create an account to access certain features. You agree to provide accurate, complete information and to keep it updated. You are responsible for maintaining the confidentiality of your login credentials and for all activities that occur under your account.
+
+## 3. User Conduct
+
+You agree not to:
+
+* Violate any applicable law or regulation  
+* Infringe the intellectual property or other rights of any person  
+* Post false, misleading, or fraudulent content or bids  
+* Transmit viruses, malware, or other harmful code  
+* Interfere with or disrupt the integrity or performance of the Services  
+* Attempt to gain unauthorized access to any part of the Services or related systems  
+
+## 4. User Content
+
+You retain all rights to content you submit (“**User Content**”). By posting User Content, you grant Giglance a worldwide, non‑exclusive, royalty‑free license to use, display, reproduce, and distribute such content solely to operate and promote the Services.
+
+You represent that you own or have the necessary rights to your User Content and that its posting does not violate any law or rights of others.
+
+## 5. Payment Terms
+
+Payments between Clients and Freelancers are processed through third‑party payment processors. Giglance is **not** a party to contracts between users and does not guarantee payment or performance. Users are responsible for any fees or taxes associated with transactions.
+
+## 6. Intellectual Property
+
+The Services and all content provided by Giglance (excluding User Content) are the exclusive property of Giglance or its licensors and are protected by copyright, trademark, and other laws. You may not copy, modify, or distribute any part of the Services unless expressly authorized.
+
+## 7. Disclaimers
+
+THE SERVICES ARE PROVIDED “AS IS” AND “AS AVAILABLE” WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED. GIGLANCE DISCLAIMS ALL WARRANTIES, INCLUDING ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON‑INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICES WILL BE ERROR‑FREE, SECURE, OR UNINTERRUPTED.
+
+## 8. Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, GIGLANCE SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES OR ANY LOSS OF PROFITS OR REVENUES, WHETHER INCURRED DIRECTLY OR INDIRECTLY, OR ANY LOSS OF DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM:  
+(a) YOUR ACCESS TO OR USE OF THE SERVICES;  
+(b) ANY CONDUCT OR CONTENT OF OTHER USERS; OR  
+(c) UNAUTHORIZED ACCESS, USE, OR ALTERATION OF YOUR CONTENT.
+
+IN NO EVENT SHALL GIGLANCE’S AGGREGATE LIABILITY EXCEED THE GREATER OF (i) INR 5,000 OR (ii) THE AMOUNT YOU PAID TO GIGLANCE, IF ANY, IN THE PAST 12 MONTHS.
+
+## 9. Indemnification
+
+You agree to indemnify, defend, and hold harmless Giglance and its officers, directors, employees, and agents from any claims, damages, losses, and expenses arising from your use of the Services or violation of these Terms.
+
+## 10. Termination
+
+We may suspend or terminate your account or access to the Services at any time, with or without notice, for any reason, including if we believe you have violated these Terms. Upon termination, your right to use the Services will immediately cease.
+
+## 11. Changes to the Terms
+
+We may modify these Terms from time to time. We will post the revised Terms and update the “Last updated” date. Continued use of the Services after changes become effective constitutes your acceptance of the revised Terms.
+
+## 12. Governing Law and Dispute Resolution
+
+These Terms are governed by the laws of India without regard to its conflict‑of‑laws principles. Any dispute arising out of or relating to these Terms or the Services shall be subject to the exclusive jurisdiction of the courts located in Ahmedabad, Gujarat, India.
+
+## 13. Miscellaneous
+
+* **Entire Agreement** — These Terms and the Privacy Policy constitute the entire agreement between you and Giglance.  
+* **Severability** — If any provision is found invalid or unenforceable, the remaining provisions shall remain in full force and effect.  
+* **No Waiver** — Our failure to enforce any right or provision shall not constitute a waiver of such right or provision.  
+* **Assignment** — You may not assign or transfer your rights under these Terms without our prior written consent. We may freely assign our rights.
+
+## 14. Contact Us
+
+If you have any questions about these Terms, please contact us at **support@giglance.com**.


### PR DESCRIPTION
## Summary

Added initial drafts of Privacy Policy and Terms of Service markdown documents for Giglance.

## Description

This PR introduces the first version of two essential legal documents:

1)privacy-policy.md: Defines how user data is collected, stored, and used by Giglance.

2)terms-of-service.md: Outlines the rules, responsibilities, and legal terms that users agree to when using the platform.

Both files are adapted from standard boilerplate templates (e.g., Termly, FreePrivacyPolicy) and customized to reflect the scope of Giglance. Unused sections (e.g., cookies, mobile app references) were removed. These drafts will be reviewed and refined further by appropriate parties.

## Images

No UI or visual changes — this PR contains only markdown files.

## Issue Addressed

Closes #8

## Prerequisites

- [✅] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/upes-open/giglance/blob/main/.github/CONTRIBUTING.md)?