### PR TITLE
#87 - fix: center sign-up and sign-in cards and ensure full height

### DIFF
--- a/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -18,7 +18,7 @@ import { Github,Loader } from 'lucide-react'
 
 export default function SignInPage() {
   return (
-    <div className='grid w-full grow items-center px-4 sm:justify-center'>
+    <div className='grid min-h-screen w-full items-center justify-center px-4'>
       <SignIn.Root>
         <Clerk.Loading>
           {isGlobalLoading => (

--- a/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -2,10 +2,8 @@ import { SignUp } from '@clerk/nextjs'
 
 export default function Page() {
   return (
-    <section className='py-24'>
-      <div className='container flex items-center justify-center'>
-        <SignUp />
-      </div>
+    <section className='min-h-screen flex items-center justify-center'>
+      <SignUp />
     </section>
   )
 }


### PR DESCRIPTION
## Summary

Centered both Sign-up and Login cards properly

Ensured full-height containers for correct vertical alignment

Kept styling consistent and minimal

## Description

This PR addresses two UI issues on the authentication pages:

Sign-up Page: The card was slightly shifted to the left. Adjusted flexbox alignment to center the card horizontally within the viewport.

Login Page: The outer container wasn't taking full height, affecting vertical alignment. Applied min-h-screen and related layout fixes to ensure the card is vertically centered.

## Images


## Issue Addressed

#87

Template should be strictly **Closes #87 **
Example: Closes #1

## Prerequisites

- [ ] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/upes-open/giglance/blob/main/.github/CONTRIBUTING.md)?